### PR TITLE
Add CI workflow for build & artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,58 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+
+env:
+  GODOT_VERSION: 4.4.1
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    container:
+      image: barichello/godot-ci:4.4.1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+          mkdir -v -p build/linux
+      - name: Build
+        run: godot --headless --export-release "Linux" ./build/linux/punk.x86_64
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Punk game - Linux
+          path: ${{ github.workspace }}/build/linux/punk.x86_64
+
+  windows:
+    runs-on: ubuntu-22.04
+    container:
+      image: barichello/godot-ci:4.4.1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - name: Setup
+        run: |
+          mkdir -v -p ~/.local/share/godot/export_templates/
+          mkdir -v -p ~/.config/
+          mv /root/.config/godot ~/.config/godot
+          mv /root/.local/share/godot/export_templates/${GODOT_VERSION}.stable ~/.local/share/godot/export_templates/${GODOT_VERSION}.stable
+          mkdir -v -p build/windows
+      - name: Build
+        run: godot --headless --export-release "Windows Desktop" ./build/windows/punk.exe
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Punk game - Windows
+          path: ${{ github.workspace }}/build/windows/punk.exe


### PR DESCRIPTION
This patch adds very basic CI that builds the game and uploads it as an artifact on two different operating systems.

It uses a https://github.com/marketplace/actions/godot-ci image.

Closes #2