### PR TITLE
Fix Windows project build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Punk game - Linux
-          path: ${{ github.workspace }}/build/linux/punk.x86_64
+          path: ${{ github.workspace }}/build/linux/
 
   windows:
     runs-on: ubuntu-22.04
@@ -55,4 +55,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Punk game - Windows
-          path: ${{ github.workspace }}/build/windows/punk.exe
+          path: ${{ github.workspace }}/build/windows/


### PR DESCRIPTION
Turns out the Windows build didn't work when it was added in f21aae0a1
('Add CI workflow for build & artifacts'). Not only the exe should
be exported but the whole build dir. This patch fixes it and changes
Linux build just in case.
